### PR TITLE
Output DSL query from query builder to allow dynamic ES querying

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,13 @@
         "rapidez/statamic": "*"
     },
     "require-dev": {
+        "laravel/pint": "^1.22",
         "orchestra/testbench": "^9.0"
     },
     "config": {
         "sort-packages": true,
         "allow-plugins": {
+            "php-http/discovery": true,
             "pixelfear/composer-dist-plugin": true
         }
     },

--- a/src/Actions/OutputsDslQueryAction.php
+++ b/src/Actions/OutputsDslQueryAction.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Actions;
+
+use Exception;
+use Rapidez\StatamicQueryBuilder\Parsers\BetweenParser;
+use Rapidez\StatamicQueryBuilder\Parsers\Dates\LastXDaysParser;
+use Rapidez\StatamicQueryBuilder\Parsers\Dates\NextXDaysParser;
+use Rapidez\StatamicQueryBuilder\Parsers\Dates\ThisMonthParser;
+use Rapidez\StatamicQueryBuilder\Parsers\Dates\ThisWeekParser;
+use Rapidez\StatamicQueryBuilder\Parsers\EndsWithParser;
+use Rapidez\StatamicQueryBuilder\Parsers\GreaterThanOrEqualParser;
+use Rapidez\StatamicQueryBuilder\Parsers\GreaterThanParser;
+use Rapidez\StatamicQueryBuilder\Parsers\InParser;
+use Rapidez\StatamicQueryBuilder\Parsers\IsNotNullParser;
+use Rapidez\StatamicQueryBuilder\Parsers\IsNullParser;
+use Rapidez\StatamicQueryBuilder\Parsers\LessThanOrEqualParser;
+use Rapidez\StatamicQueryBuilder\Parsers\LessThanParser;
+use Rapidez\StatamicQueryBuilder\Parsers\LikeParser;
+use Rapidez\StatamicQueryBuilder\Parsers\NotBetweenParser;
+use Rapidez\StatamicQueryBuilder\Parsers\NotInParser;
+use Rapidez\StatamicQueryBuilder\Parsers\NotLikeParser;
+use Rapidez\StatamicQueryBuilder\Parsers\NotTermParser;
+use Rapidez\StatamicQueryBuilder\Parsers\StartsWithParser;
+use Rapidez\StatamicQueryBuilder\Parsers\TermParser;
+
+class OutputsDslQueryAction
+{
+    protected array $operators = [
+        '=' => TermParser::class,
+        '!=' => NotTermParser::class,
+        'LIKE' => LikeParser::class,
+        'NOT LIKE' => NotLikeParser::class,
+        'STARTS_WITH' => StartsWithParser::class,
+        'ENDS_WITH' => EndsWithParser::class,
+        'IN' => InParser::class,
+        'NOT IN' => NotInParser::class,
+        '>' => GreaterThanParser::class,
+        '<' => LessThanParser::class,
+        '>=' => GreaterThanOrEqualParser::class,
+        '<=' => LessThanOrEqualParser::class,
+        'BETWEEN' => BetweenParser::class,
+        'NOT_BETWEEN' => NotBetweenParser::class,
+        'IS_NULL' => IsNullParser::class,
+        'IS_NOT_NULL' => IsNotNullParser::class,
+        'LAST_X_DAYS' => LastXDaysParser::class,
+        'NEXT_X_DAYS' => NextXDaysParser::class,
+        'THIS_WEEK' => ThisWeekParser::class,
+        'THIS_MONTH' => ThisMonthParser::class,
+    ];
+
+    public function build(array $config): array
+    {
+        $groupConjunction = strtoupper($config['globalConjunction'] ?? 'AND');
+        $globalKey = $groupConjunction === 'OR' ? 'should' : 'must';
+        $groups = $config['groups'] ?? [];
+        $limit = (int) ($config['limit'] ?? 10);
+
+        $clauses = [];
+
+        foreach ($groups as $group) {
+            $groupConjunction = strtoupper($group['conjunction'] ?? 'AND');
+            $groupKey = $groupConjunction === 'OR' ? 'should' : 'must';
+            $conditions = [];
+
+            foreach ($group['conditions'] as $cond) {
+                $conditions[] = $this->mapCondition($cond);
+            }
+
+            if (count($groups) === 1 && $groupKey === $globalKey) {
+                $clauses = array_merge($clauses, $conditions);
+            } else {
+                $clauses[] = ['bool' => [$groupKey => $conditions]];
+            }
+        }
+
+        return [
+            'query' => ['bool' => [$globalKey => $clauses]],
+            'size' => $limit,
+            'from' => 0,
+        ];
+    }
+
+    private function mapCondition(array $condition): array
+    {
+        $operator = strtoupper($condition['operator']);
+        $field = $condition['attribute'];
+        $value = $condition['value'] ?? null;
+
+        if (! isset($this->operators[$operator])) {
+            throw new Exception("Unsupported operator: {$operator}");
+        }
+
+        $parserClass = $this->operators[$operator];
+        $parser = new $parserClass;
+
+        return $parser->parse($field, $value);
+    }
+}

--- a/src/Contracts/ParsesOperator.php
+++ b/src/Contracts/ParsesOperator.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Contracts;
+
+interface ParsesOperator
+{
+    public function parse(string $field, mixed $value): array;
+}

--- a/src/Fieldtypes/ProductQueryBuilder.php
+++ b/src/Fieldtypes/ProductQueryBuilder.php
@@ -2,14 +2,17 @@
 
 namespace Rapidez\StatamicQueryBuilder\Fieldtypes;
 
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\DB;
+use Rapidez\StatamicQueryBuilder\Actions\OutputsDslQueryAction;
 use Statamic\Fields\Fieldtype;
 
 class ProductQueryBuilder extends Fieldtype
 {
     protected $icon = 'filter';
+
+    public function __construct(
+        protected OutputsDslQueryAction $outputsDslQueryAction
+    ) {}
 
     public function defaultValue()
     {
@@ -17,287 +20,48 @@ class ProductQueryBuilder extends Fieldtype
             'groups' => [
                 [
                     'conjunction' => 'AND',
-                    'conditions' => []
-                ]
+                    'conditions' => [],
+                ],
             ],
             'globalConjunction' => 'AND',
             'limit' => 100,
-            'products' => []
+            'products' => [],
         ];
     }
 
     public function process($data)
     {
-        $data['products'] = $this->getProducts($data, true);
+        $data['value'] = $this->getValue($data, true);
 
         return $data;
     }
 
     public function augment($value)
     {
-        $value['products'] = $this->getProducts($value);
+        unset($value['products']);
+
+        $value['value'] = $this->getValue($value);
 
         return $value;
     }
 
-    public function getProducts(array $data, bool $force = false): array
+    public function getValue(array $value, bool $force = false)
     {
-        if (isset($data['products'])) {
-            unset($data['products']);
-        }
-
-        $cacheKey = 'product-query-builder-' . config('rapidez.store') . '-' . md5(json_encode($data));
+        $cacheKey = 'product-query-builder-'.config('rapidez.store').'-'.md5(json_encode($value));
 
         if ($force && Cache::has($cacheKey)) {
-            Cache::forget($cacheKey);
+            return Cache::forget($cacheKey);
         }
 
-        $data['products'] = Cache::remember($cacheKey, Carbon::now()->addDay(), function() use ($data) {
-            return $this->toSkus($data);
-        });
+        if (Cache::has($cacheKey)) {
+            return Cache::get($cacheKey);
+        }
 
-        return $data['products'];
+        return Cache::remember($cacheKey, now()->addDay(), fn () => $this->getDsl($value));
     }
 
-    public function toSkus($data): array
+    public function getDsl(array $value)
     {
-        $model = config('rapidez.models.product');
-        $table = 'catalog_product_flat_' . config('rapidez.store');
-        $query = $model::query()->select($table . '.sku');
-
-        if (empty($data['groups'])) {
-            return $query->limit($data['limit'] ?? 100)->pluck($table . '.sku')->toArray();
-        }
-
-        $globalMethod = strtolower($data['globalConjunction'] ?? 'AND') === 'and' ? 'where' : 'orWhere';
-
-        foreach ($data['groups'] as $group) {
-            if (empty($group['conditions'])) {
-                continue;
-            }
-
-            $query->$globalMethod(function($query) use ($group, $table) {
-                foreach ($group['conditions'] as $condition) {
-                    if (empty($condition['attribute']) || empty($condition['operator'])) {
-                        continue;
-                    }
-
-                    $value = $condition['value'];
-                    $operator = $condition['operator'];
-                    $column = $table . '.' . $condition['attribute'];
-                    $method = strtolower($group['conjunction'] ?? 'AND') === 'and' ? 'where' : 'orWhere';
-
-                    $query = $this->applyOperator($query, $method, $column, $operator, $value);
-                }
-            });
-        }
-
-        return $query->limit($data['limit'] ?? 100)->pluck($table . '.sku')->toArray();
-    }
-
-    public function toSkusEav($data): array
-    {
-        $storeId = config('rapidez.store');
-
-        $innerQuery = DB::table('catalog_product_entity')
-            ->select('catalog_product_entity.entity_id', 'catalog_product_entity.sku');
-
-        $attributeJoins = [];
-        foreach ($data['groups'] as $group) {
-            if (empty($group['conditions'])) {
-                continue;
-            }
-
-            foreach ($group['conditions'] as $i => $condition) {
-                if (empty($condition['attribute']) || empty($condition['operator'])) {
-                    continue;
-                }
-
-                $attribute = $condition['attribute'];
-                if (!isset($attributeJoins[$attribute])) {
-                    $backendType = DB::table('eav_attribute')
-                        ->join('eav_entity_type', 'eav_entity_type.entity_type_id', '=', 'eav_attribute.entity_type_id')
-                        ->where('eav_entity_type.entity_type_code', '=', 'catalog_product')
-                        ->where('eav_attribute.attribute_code', '=', $attribute)
-                        ->value('backend_type');
-
-                    if ($backendType && $backendType !== 'static') {
-                        $attributeJoins[$attribute] = [
-                            'type' => $backendType,
-                            'instances' => []
-                        ];
-                    }
-                }
-
-                if (isset($attributeJoins[$attribute])) {
-                    $attributeJoins[$attribute]['instances'][] = $i;
-                }
-            }
-        }
-
-        foreach ($attributeJoins as $attribute => $info) {
-            foreach ($info['instances'] as $i) {
-                $alias = "eav_{$attribute}_{$i}";
-                $backendType = $info['type'];
-                $attributeId = DB::table('eav_attribute')
-                    ->where('attribute_code', '=', $attribute)
-                    ->where('entity_type_id', function($query) {
-                        $query->select('entity_type_id')
-                            ->from('eav_entity_type')
-                            ->where('entity_type_code', '=', 'catalog_product')
-                            ->limit(1);
-                    })
-                    ->value('attribute_id');
-
-                if (!$attributeId) {
-                    continue;
-                }
-
-                $innerQuery->selectRaw("COALESCE(
-                    (SELECT value FROM catalog_product_entity_{$backendType}
-                     WHERE entity_id = catalog_product_entity.entity_id
-                     AND attribute_id = {$attributeId}
-                     AND store_id = {$storeId}
-                     LIMIT 1),
-                    (SELECT value FROM catalog_product_entity_{$backendType}
-                     WHERE entity_id = catalog_product_entity.entity_id
-                     AND attribute_id = {$attributeId}
-                     AND store_id = 0
-                     LIMIT 1)
-                ) as {$alias}_value");
-            }
-        }
-
-        $query = DB::table(DB::raw("({$innerQuery->toSql()}) as inner_query"))
-            ->select('inner_query.sku')
-            ->distinct()
-            ->mergeBindings($innerQuery);
-
-        $globalMethod = strtolower($data['globalConjunction'] ?? 'AND') === 'and' ? 'where' : 'orWhere';
-
-        foreach ($data['groups'] as $group) {
-            if (empty($group['conditions'])) {
-                continue;
-            }
-
-            $query->$globalMethod(function($query) use ($group, $attributeJoins) {
-                foreach ($group['conditions'] as $i => $condition) {
-                    if (empty($condition['attribute']) || empty($condition['operator'])) {
-                        continue;
-                    }
-
-                    $value = $condition['value'];
-                    $operator = $condition['operator'];
-                    $attribute = $condition['attribute'];
-                    $method = strtolower($group['conjunction'] ?? 'AND') === 'and' ? 'where' : 'orWhere';
-
-                    if (isset($attributeJoins[$attribute])) {
-                        $alias = "eav_{$attribute}_{$i}";
-                        $column = "inner_query.{$alias}_value";
-
-                        if ($attribute === 'price') {
-                            $customerGroupId = config('rapidez.customer_group', 0);
-                            $websiteId = config('rapidez.website');
-
-                            $column = DB::raw("LEAST(inner_query.{$alias}_value,
-                                COALESCE((
-                                    SELECT MIN(price)
-                                    FROM catalog_product_entity_tier_price
-                                    WHERE entity_id = inner_query.entity_id
-                                    AND customer_group_id = {$customerGroupId}
-                                    AND website_id IN (0, {$websiteId})
-                                ), inner_query.{$alias}_value)
-                            )");
-                        }
-                    } else {
-                        $column = "inner_query.{$attribute}";
-                    }
-
-                    $query = $this->applyOperator($query, $method, $column, $operator, $value);
-                }
-            });
-        }
-
-        if (!empty($data['type_filter'])) {
-            $query->where('inner_query.type_id', 'NOT IN', $data['type_filter']);
-        }
-
-        return $query->limit($data['limit'] ?? 100)->pluck('sku')->toArray();
-    }
-
-    private function applyOperator($query, $method, $column, $operator, $value)
-    {
-        switch ($operator) {
-            case 'IN':
-            case 'NOT IN':
-                $values = is_array($value) ? $value : explode(',', $value);
-                $method = $operator === 'IN' ? $method.'In' : $method.'NotIn';
-                $query->$method($column, $values);
-                break;
-
-            case 'LIKE':
-            case 'NOT LIKE':
-                $query->$method($column, $operator, '%' . $value . '%');
-                break;
-
-            case 'STARTS_WITH':
-                $query->$method($column, 'LIKE', $value . '%');
-                break;
-
-            case 'ENDS_WITH':
-                $query->$method($column, 'LIKE', '%' . $value);
-                break;
-
-            case 'IS_NULL':
-                $query->whereNull($column);
-                break;
-
-            case 'IS_NOT_NULL':
-                $query->whereNotNull($column);
-                break;
-
-            case 'BETWEEN':
-            case 'NOT_BETWEEN':
-                if (is_array($value) && isset($value[0], $value[1]) && $value[0] !== '' && $value[1] !== '') {
-                    $method = $operator === 'BETWEEN' ? 'whereBetween' : 'whereNotBetween';
-                    $query->$method($column, [$value[0], $value[1]]);
-                }
-                break;
-
-            case 'LAST_X_DAYS':
-                if (is_numeric($value)) {
-                    $query->$method($column, '>=', now()->subDays((int) $value)->startOfDay());
-                }
-                break;
-
-            case 'NEXT_X_DAYS':
-                if (is_numeric($value)) {
-                    $query->$method($column, '<=', now()->addDays((int) $value)->endOfDay());
-                }
-                break;
-
-            case 'THIS_WEEK':
-                $query->whereBetween($column, [now()->startOfWeek(), now()->endOfWeek()]);
-                break;
-
-            case 'THIS_MONTH':
-                $query->whereBetween($column, [now()->startOfMonth(), now()->endOfMonth()]);
-                break;
-
-            default:
-                $operator = match($operator) {
-                    '=' => '=',
-                    '!=' => '<>',
-                    '>' => '>',
-                    '>=' => '>=',
-                    '<' => '<',
-                    '<=' => '<=',
-                    default => '='
-                };
-                $query->$method($column, $operator, $value);
-                break;
-        }
-
-        return $query;
+        return $this->outputsDslQueryAction->build($value);
     }
 }

--- a/src/Fieldtypes/QueryBuilder.php
+++ b/src/Fieldtypes/QueryBuilder.php
@@ -15,6 +15,7 @@ class QueryBuilder extends Fieldtype
     public function setFields(array $fields): self
     {
         $this->fields = $fields;
+
         return $this;
     }
 
@@ -24,11 +25,11 @@ class QueryBuilder extends Fieldtype
             'groups' => [
                 [
                     'conjunction' => 'AND',
-                    'conditions' => []
-                ]
+                    'conditions' => [],
+                ],
             ],
             'globalConjunction' => 'AND',
-            'limit' => 100
+            'limit' => 100,
         ];
     }
 
@@ -40,7 +41,7 @@ class QueryBuilder extends Fieldtype
                 'text' => ['=', '!=', 'LIKE', 'NOT LIKE', 'STARTS_WITH', 'ENDS_WITH', 'IS_NULL', 'IS_NOT_NULL'],
                 'select' => ['=', '!=', 'IN', 'NOT IN', 'IS_NULL', 'IS_NOT_NULL'],
                 'number' => ['=', '!=', '>', '<', '>=', '<=', 'BETWEEN', 'NOT_BETWEEN', 'IS_NULL', 'IS_NOT_NULL'],
-                'date' => ['=', '!=', '>', '<', '>=', '<=', 'BETWEEN', 'NOT_BETWEEN', 'LAST_X_DAYS', 'NEXT_X_DAYS', 'THIS_WEEK', 'THIS_MONTH']
+                'date' => ['=', '!=', '>', '<', '>=', '<=', 'BETWEEN', 'NOT_BETWEEN', 'LAST_X_DAYS', 'NEXT_X_DAYS', 'THIS_WEEK', 'THIS_MONTH'],
             ],
             'defaultLimit' => 100,
             'showLimit' => true,

--- a/src/Http/Controllers/CP/ProductAttributeController.php
+++ b/src/Http/Controllers/CP/ProductAttributeController.php
@@ -2,7 +2,7 @@
 
 namespace Rapidez\StatamicQueryBuilder\Http\Controllers\CP;
 
-use Rapidez\Statamic\Models\ProductAttribute;
+use App\Models\ProductAttribute;
 use Statamic\Http\Controllers\CP\CpController;
 
 class ProductAttributeController extends CpController

--- a/src/Parsers/BetweenParser.php
+++ b/src/Parsers/BetweenParser.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+use Exception;
+use Rapidez\StatamicQueryBuilder\Contracts\ParsesOperator;
+
+class BetweenParser implements ParsesOperator
+{
+    public function parse(string $field, mixed $value): array
+    {
+        if (! is_array($value) || count($value) !== 2) {
+            throw new Exception('BETWEEN requires two values');
+        }
+
+        return ['range' => [$field => ['gte' => $value[0], 'lte' => $value[1]]]];
+    }
+}

--- a/src/Parsers/Dates/DateRangeParser.php
+++ b/src/Parsers/Dates/DateRangeParser.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers\Dates;
+
+use Rapidez\StatamicQueryBuilder\Contracts\ParsesOperator;
+
+abstract class DateRangeParser implements ParsesOperator
+{
+    protected string $rangeClause;
+
+    public function parse(string $field, $value): array
+    {
+        return ['bool' => ['should' => [['range' => [$field => $this->buildRange($value)]]]]];
+    }
+
+    abstract protected function buildRange(string $value): array;
+}

--- a/src/Parsers/Dates/LastXDaysParser.php
+++ b/src/Parsers/Dates/LastXDaysParser.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers\Dates;
+
+class LastXDaysParser extends DateRangeParser
+{
+    protected function buildRange(string $value): array
+    {
+        return ['gte' => "now-{$value}d/d", 'lte' => 'now/d'];
+    }
+}

--- a/src/Parsers/Dates/NextXDaysParser.php
+++ b/src/Parsers/Dates/NextXDaysParser.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers\Dates;
+
+class NextXDaysParser extends DateRangeParser
+{
+    protected function buildRange(string $value): array
+    {
+        return ['gte' => 'now/d', 'lte' => "now+{$value}d/d"];
+    }
+}

--- a/src/Parsers/Dates/ThisMonthParser.php
+++ b/src/Parsers/Dates/ThisMonthParser.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers\Dates;
+
+class ThisMonthParser extends DateRangeParser
+{
+    protected function buildRange(string $value): array
+    {
+        return ['gte' => 'now/M', 'lt' => 'now+1M/M'];
+    }
+}

--- a/src/Parsers/Dates/ThisWeekParser.php
+++ b/src/Parsers/Dates/ThisWeekParser.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers\Dates;
+
+class ThisWeekParser extends DateRangeParser
+{
+    protected function buildRange(string $value): array
+    {
+        return ['gte' => 'now/w', 'lt' => 'now+1w/w'];
+    }
+}

--- a/src/Parsers/EndsWithParser.php
+++ b/src/Parsers/EndsWithParser.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+use Rapidez\StatamicQueryBuilder\Contracts\ParsesOperator;
+
+class EndsWithParser implements ParsesOperator
+{
+    public function parse(string $field, mixed $value): array
+    {
+        return [
+            'wildcard' => [
+                $field.'.keyword' => [
+                    'value' => "*{$value}",
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Parsers/GreaterThanOrEqualParser.php
+++ b/src/Parsers/GreaterThanOrEqualParser.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+class GreaterThanOrEqualParser extends RangeParser
+{
+    protected $operator = 'gte';
+}

--- a/src/Parsers/GreaterThanParser.php
+++ b/src/Parsers/GreaterThanParser.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+class GreaterThanParser extends RangeParser
+{
+    protected string $operator = 'gt';
+}

--- a/src/Parsers/InParser.php
+++ b/src/Parsers/InParser.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+use Rapidez\StatamicQueryBuilder\Contracts\ParsesOperator;
+
+class InParser implements ParsesOperator
+{
+    public function parse(string $field, mixed $value): array
+    {
+        return ['terms' => [$field => (array) $value]];
+    }
+}

--- a/src/Parsers/IsNotNullParser.php
+++ b/src/Parsers/IsNotNullParser.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+use Rapidez\StatamicQueryBuilder\Contracts\ParsesOperator;
+
+class IsNotNullParser implements ParsesOperator
+{
+    public function parse(string $field, $value): array
+    {
+        return ['exists' => ['field' => $field]];
+    }
+}

--- a/src/Parsers/IsNullParser.php
+++ b/src/Parsers/IsNullParser.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+use Rapidez\StatamicQueryBuilder\Contracts\ParsesOperator;
+
+class IsNullParser implements ParsesOperator
+{
+    public function parse(string $field, $value): array
+    {
+        return [
+            'bool' => [
+                'must_not' => [
+                    'exists' => [
+                        'field' => $field,
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Parsers/LessThanOrEqualParser.php
+++ b/src/Parsers/LessThanOrEqualParser.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+class LessThanOrEqualParser extends RangeParser
+{
+    protected $operator = 'lte';
+}

--- a/src/Parsers/LessThanParser.php
+++ b/src/Parsers/LessThanParser.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+class LessThanParser extends RangeParser
+{
+    protected string $operator = 'lt';
+}

--- a/src/Parsers/LikeParser.php
+++ b/src/Parsers/LikeParser.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+use Rapidez\StatamicQueryBuilder\Contracts\ParsesOperator;
+
+class LikeParser implements ParsesOperator
+{
+    public function parse(string $field, mixed $value): array
+    {
+        return [
+            'wildcard' => [
+                $field => "*{$value}*",
+            ],
+        ];
+    }
+}

--- a/src/Parsers/NotBetweenParser.php
+++ b/src/Parsers/NotBetweenParser.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+use Exception;
+use Rapidez\StatamicQueryBuilder\Contracts\ParsesOperator;
+
+class NotBetweenParser implements ParsesOperator
+{
+    public function parse(string $field, $value): array
+    {
+        if (! is_array($value) || count($value) !== 2) {
+            throw new Exception('NOT_BETWEEN requires two values');
+        }
+
+        return ['bool' => ['must_not' => [['range' => [$field => ['gte' => $value[0], 'lte' => $value[1]]]]]]];
+    }
+}

--- a/src/Parsers/NotInParser.php
+++ b/src/Parsers/NotInParser.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+use Rapidez\StatamicQueryBuilder\Contracts\ParsesOperator;
+
+class NotInParser implements ParsesOperator
+{
+    public function parse(string $field, mixed $value): array
+    {
+        return ['bool' => ['must_not' => [['terms' => [$field => (array) $value]]]]];
+    }
+}

--- a/src/Parsers/NotLikeParser.php
+++ b/src/Parsers/NotLikeParser.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+use Rapidez\StatamicQueryBuilder\Contracts\ParsesOperator;
+
+class NotLikeParser implements ParsesOperator
+{
+    public function parse(string $field, mixed $value): array
+    {
+        return [
+            'bool' => [
+                'must_not' => [
+                    [
+                        'wildcard' => [
+                            $field.'.keyword' => [
+                                'value' => "*{$value}*",
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Parsers/NotTermParser.php
+++ b/src/Parsers/NotTermParser.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+use Rapidez\StatamicQueryBuilder\Contracts\ParsesOperator;
+
+class NotTermParser implements ParsesOperator
+{
+    public function parse(string $field, mixed $value): array
+    {
+        return [
+            'bool' => [
+                'must_not' => [
+                    [
+                        'term' => [
+                            $field => $value,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Parsers/RangeParser.php
+++ b/src/Parsers/RangeParser.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+use Rapidez\StatamicQueryBuilder\Contracts\ParsesOperator;
+
+class RangeParser implements ParsesOperator
+{
+    protected string $operator;
+
+    public function parse(string $field, mixed $value): array
+    {
+        return [
+            'bool' => [
+                'should' => [
+                    [
+                        'range' => [
+                            $field => [
+                                $this->operator => $value,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Parsers/StartsWithParser.php
+++ b/src/Parsers/StartsWithParser.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+use Rapidez\StatamicQueryBuilder\Contracts\ParsesOperator;
+
+class StartsWithParser implements ParsesOperator
+{
+    public function parse(string $field, mixed $value): array
+    {
+        return [
+            'wildcard' => [
+                $field.'.keyword' => [
+                    'value' => "{$value}*",
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Parsers/TermParser.php
+++ b/src/Parsers/TermParser.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rapidez\StatamicQueryBuilder\Parsers;
+
+use Rapidez\StatamicQueryBuilder\Contracts\ParsesOperator;
+
+class TermParser implements ParsesOperator
+{
+    public function parse(string $field, mixed $value): array
+    {
+        return [
+            'term' => [
+                $field => $value,
+            ],
+        ];
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Rapidez\StatamicQueryBuilder;
 
+use Rapidez\StatamicQueryBuilder\Actions\OutputsDslQueryAction;
 use Rapidez\StatamicQueryBuilder\Fieldtypes\ProductQueryBuilder;
 use Statamic\Providers\AddonServiceProvider;
 
@@ -9,7 +10,7 @@ class ServiceProvider extends AddonServiceProvider
 {
     protected $vite = [
         'input' => [
-            'resources/js/statamic-query-builder.js'
+            'resources/js/statamic-query-builder.js',
         ],
         'publicDirectory' => 'resources/dist',
     ];
@@ -17,4 +18,9 @@ class ServiceProvider extends AddonServiceProvider
     protected $fieldtypes = [
         ProductQueryBuilder::class,
     ];
+
+    public function bootAddon()
+    {
+        $this->app->singleton(OutputsDslQueryAction::class);
+    }
 }


### PR DESCRIPTION
I've converted the output of ids to DSL query. This way if new items in elasticsearch match the query build with the query builder, they automaticly get displayed in the output. This is an improvement when using static caching. The previous solution just outputs product skus which are not updated. 

I've tried the following solutions
*SQL*
Elasticsearch allows querying based on SQL, however it uses another endpoint then the endpoint that reactivesearch uses. Also we usually query all the fields, which is nog possible because the sql endpoint does not support outputting array fields. So we would be missing things like categories, images etc.

*Query string query*
This worked too but resulted in pretty unreadable code on the query builder side. 

*DSL*
I've chosen this way because we already use it. I've made a parser class for each condition for easy extendability and readability. 


Some issues still need to be figured out:
* When querying a text field, the field needs to be  appended ".keyword". When it's not a text field it does not. 
* Test with Rapidez core v4 and instantsearch and make changes accordingly
